### PR TITLE
Add missing includes of pddl_exception.h

### DIFF
--- a/include/clips_pddl_parser/effect_visitor.h
+++ b/include/clips_pddl_parser/effect_visitor.h
@@ -22,6 +22,7 @@
 #define CLIPS_PDDL_PARSER_EFFECT_VISITOR_H_
 
 #include <pddl_parser/pddl_parser.h>
+#include <pddl_parser/pddl_exception.h>
 
 #include <boost/variant/variant.hpp>
 #include <string>

--- a/include/clips_pddl_parser/precondition_visitor.h
+++ b/include/clips_pddl_parser/precondition_visitor.h
@@ -22,6 +22,7 @@
 #define _PLUGINS_CLIPS_PDDL_PARSER_PRECONDITION_VISITOR_H_
 
 #include <pddl_parser/pddl_parser.h>
+#include <pddl_parser/pddl_exception.h>
 
 #include <boost/variant/variant.hpp>
 #include <string>

--- a/src/clips_pddl_parser.cpp
+++ b/src/clips_pddl_parser.cpp
@@ -39,6 +39,7 @@
 #include <clips_pddl_parser/effect_visitor.h>
 #include <clips_pddl_parser/precondition_visitor.h>
 #include <pddl_parser/pddl_parser.h>
+#include <pddl_parser/pddl_exception.h>
 #include <spdlog/spdlog.h>
 
 #include <clipsmm.h>


### PR DESCRIPTION
This is required in order to build on Fedora 35.